### PR TITLE
Rust: Feature: Remotely trigger Jenkins jobs from a JSON file.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = [
+    "libs/utils",
+    "apps/ci_jenkins",
+]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# evoadapt
+<div align="center">
+<!-- Title: -->
+<h1><a href="https://github.com/huyle-anh/evoadapt/">Evoadapt</a> - Rust</h1>
+
+<!-- Short description: -->
+  <h3>The ideas are implemented in Rust - for learning</h3>
+</div>
+
+
+### List of learn
+
+
+### Contributing
+
+### Compile
+ ci_jenkins
+ cargo build -p ci_jenkins
+ cargo run -p ci_jenkins
+ cargo build --release ci_jenkins
+ cargo clean
+
+### Run
+ci_jenkins_trigger /<path>/jenkinsCfg.json
+
+### To Add package
+cargo add some_library --package my_package
+

--- a/apps/ci_jenkins/Cargo.toml
+++ b/apps/ci_jenkins/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ci_jenkins"
+version = "0.1.0"
+edition = "2021"
+description = "Library to trigger jenkin using JSON config file"
+authors = ["HuyAnhLe anhhuy@live.com"]
+
+[dependencies]
+common = { path = "../../libs/utils" }
+reqwest = { version = "0.11", features = ["json", "blocking"] }
+serde_json = "1.0"
+chrono = "0.4" # Library for get time

--- a/apps/ci_jenkins/src/main.rs
+++ b/apps/ci_jenkins/src/main.rs
@@ -1,0 +1,94 @@
+use common::utils;
+use std::error::Error;
+//use std::process; // -> //process::exit(1);
+use std::env;
+/*
+const JENKIN_USER: &str = "hule";
+const JENKIN_TOKEN: &str = "1113cacf21918e88d02a333232a08c8efb";
+const JENKINS_URL: &str = "https://jenkin.com";
+const DAILY_REBASE_CHECK: &str = "OBMC_Daily_Rebase_Check";
+const DAILY_MAIN_CHECK: &str = "OBMC_Daily_Main_Check";
+const DAILY_RERGESSION_TEST: &str = "OBMC_Daily_Regression_Test";
+const JENKINS_JOB_NAME: &str = "temp";
+*/
+
+fn main() -> Result<(), Box<dyn Error>> {
+    /*
+     * Check argument to print usage for user
+     */
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <json Config File Path>", args[0]);
+        return Ok(());
+    }
+    let json_cfg_file_path = &args[1];
+
+    /*
+     * Call trigger Jenkin Job
+     */
+    let current_dir = env::current_dir().unwrap();
+    println!("Current dir: {}", current_dir.display());
+    let config = utils::read_json_cfg(json_cfg_file_path)?;
+    println!(" Json config file path: {:?}", json_cfg_file_path);
+    let jenkin_user = config.jenkin_user.clone();
+    let jenkin_token = config.jenkin_token.clone();
+    let jenkin_url = config.jenkin_url.clone();
+    let daily_rebase_check = config.daily_rebase_check.clone();
+    let daily_main_check = config.daily_main_check.clone();
+    let daily_rergression_test = config.daily_rergression_test.clone();
+    //let _timeout = config.as_ref().unwrap().timeout.clone();
+    match utils::trigger_jenkins_job(
+        &jenkin_user,
+        &jenkin_token,
+        &jenkin_url,
+        &daily_rebase_check,
+    ) {
+        Ok((_trigger_url, build_id)) => {
+            println!(
+                "Trigger Rebase-URL successfully: {}/job/{}/{}",
+                jenkin_url, daily_rebase_check, build_id
+            );
+            println!("Build ID: {}", build_id);
+            match utils::check_jenkins_job_status(
+                &json_cfg_file_path,
+                &jenkin_user,
+                &jenkin_token,
+                &jenkin_url,
+                &daily_rebase_check,
+                &build_id, // | build_id.c_str()
+                &daily_rergression_test,
+            ) {
+                Ok(_status) => {
+                    println!("Next run daily_main_check");
+                    match utils::trigger_jenkins_job(
+                        &jenkin_user,
+                        &jenkin_token,
+                        &jenkin_url,
+                        &daily_main_check,
+                    ) {
+                        Ok((_trigger_url, build_id)) => {
+                            println!(
+                                "Trigger Main-URL successfully: {}/job/{}/{}",
+                                jenkin_url, daily_main_check, build_id
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to trigger Jenkins Job: {}", e);
+                            return Err(e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Failed to check Status: {}", e);
+                    return Err(e);
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to trigger Jenkins Job: {}", e);
+            return Err(e);
+        }
+    }
+
+    Ok(())
+}

--- a/configs/jenkinsCfg.json
+++ b/configs/jenkinsCfg.json
@@ -1,0 +1,9 @@
+{
+    "jenkin_user": "hule",
+    "jenkin_token": "1113cacf21918e88d02a333232a08c8efb",
+    "jenkin_url": "https://server.jenkin.com",
+    "daily_rebase_check": "OBMC_Daily_Rebase_Check",
+    "daily_main_check": "OBMC_Daily_Main_Check",
+    "daily_rergression_test": "OBMC_Daily_Regression_Test",
+    "time_out": 36000
+}

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "common"
+version = "0.1.0"
+edition = "2021"
+description = "Library common"
+authors = ["HuyAnhLe anhhuy@live.com"]
+
+[dependencies]
+reqwest = { version = "0.11", features = ["json", "blocking"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = "0.4" # Library for get time

--- a/libs/utils/src/lib.rs
+++ b/libs/utils/src/lib.rs
@@ -1,0 +1,227 @@
+/// The Library includes the function for common using.
+pub mod utils {
+    use reqwest::{blocking::Client, header::CONTENT_TYPE};
+    //use reqwest::blocking::Client;
+    //use reqwest::header::CONTENT_TYPE;
+    use chrono::Utc;
+    use serde_json::Value;
+    use std::error::Error;
+    use std::thread::sleep;
+    use std::time::Duration; // for get Time
+                             //const TIMEOUT: u16 = 36000; // 10 * 60 * 60 = 36000 seconds
+    /*
+     * Get Test of Lib Call
+     */
+    pub fn hello() {
+        println!("Hello, I'm libs in common");
+    }
+
+    /*
+     * To Trigger an Jenkin Job remote
+     */
+    pub fn trigger_jenkins_job(
+        jenkins_user: &str,
+        jenkins_token: &str,
+        jenkins_url: &str,
+        jenkins_job_name: &str,
+    ) -> Result<(String, String), Box<dyn Error>> {
+        let client = Client::new();
+
+        /*
+         * Trigging job to jenkins
+         */
+        println!("Triggering Jenkins Job Name: {}", jenkins_job_name);
+        let build_response = client
+            .post(format!("{}/job/{}/build", jenkins_url, jenkins_job_name))
+            .basic_auth(jenkins_user, Some(jenkins_token))
+            .header(CONTENT_TYPE, "application/json")
+            .send()?;
+
+        /*
+         * Check status job trigger before
+         */
+        let trigger_url = build_response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|location| location.to_str().ok())
+            .map(|s| s.to_string());
+        if trigger_url.is_none() {
+            println!("Failed to trigger Jenkins Job {}", jenkins_job_name);
+            return Err("Failed to trigger Jenkins Job".into());
+        }
+        // Method .unwrap to open value inside Option or Result, if None -> error panic
+        let trigger_url = trigger_url.unwrap();
+
+        /*
+         * Get BUILD_ID of Jenkin Job
+         */
+        let mut build_id = String::new();
+        while build_id.is_empty() {
+            sleep(Duration::from_secs(15));
+            let last_build_response = client
+                .get(format!(
+                    "{}/job/{}/lastBuild/api/json",
+                    jenkins_url, jenkins_job_name
+                ))
+                .basic_auth(jenkins_user, Some(jenkins_token))
+                .send()?;
+            let json: Value = last_build_response.json()?;
+            build_id = json["id"].as_str().unwrap_or("").to_string();
+        }
+
+        println!(
+            "Triggered Jenkins BUILD URL: {}/job/{}/{}",
+            jenkins_url, jenkins_job_name, build_id
+        );
+
+        Ok((trigger_url, build_id))
+    }
+
+    /*
+     * To get last build job ID
+     */
+    pub fn get_last_build_id(
+        jenkins_user: &str,
+        jenkins_token: &str,
+        jenkins_url: &str,
+        job_name: &str,
+    ) -> Result<String, Box<dyn Error>> {
+        let url = format!("{}/job/{}/lastBuild/api/json", jenkins_url, job_name);
+        let client = reqwest::blocking::Client::new();
+        let response = client
+            .get(&url)
+            .basic_auth(jenkins_user, Some(jenkins_token))
+            .send()?
+            .text()?;
+        let json: Value = serde_json::from_str(&response)?;
+        Ok(json["id"].as_str().unwrap_or("").to_string())
+    }
+
+    /*
+     * To check jenkin job status
+     */
+    pub fn check_jenkins_job_status(
+        file_path: &str,
+        jenkins_user: &str,
+        jenkins_token: &str,
+        jenkins_url: &str,
+        jenkins_job_name: &str,
+        build_id: &str,
+        daily_regression_test: &str,
+    ) -> Result<(), Box<dyn Error>> {
+        let start_time = Utc::now();
+        println!("check_jenkins_job_status...");
+        loop {
+            /*
+             * Get status of Jenkin Job
+             */
+            println!("loop...");
+            let url = format!(
+                "{}/job/{}/{}/api/json",
+                jenkins_url, jenkins_job_name, build_id
+            );
+            let client = reqwest::blocking::Client::new();
+            let response = client
+                .get(&url)
+                .basic_auth(jenkins_user, Some(jenkins_token))
+                .send()?
+                .text()?;
+
+            /*
+             * Analyzer to get status of Job
+             */
+            let json: Value = serde_json::from_str(&response)?;
+            let status = json["result"].as_str().unwrap_or("null");
+            if status != "null" {
+                // Job complete with status SUCCESS | ABORTED | FAILURE
+                println!("Jenkins job completed with status: {}.", status);
+                return Ok(());
+            }
+
+            let end_time = Utc::now();
+            let elapsed_time = (end_time.timestamp() - start_time.timestamp()) as u16;
+            println!("Elapse_time: {}", elapsed_time);
+            //let config = read_json_cfg("../configs/jenkinsCfg.json");
+            let config = read_json_cfg(file_path)?;
+            //let config = read_json_cfg(
+            //    "
+            //        /evoadapt/jenkins/rust/botevoadapt/configs/jenkinsCfg.json",
+            //)
+            //.expect(
+            //    "Lib: Failed to read config file,
+            //                check the file path and ensure the file exists.",
+            //);
+            let timeout: u16 = config.time_out;
+
+            if elapsed_time >= timeout {
+                println!(
+                    "
+                        Jenkins job exceeded maximum time allowed ({} seconds).
+                        Attempting to abort job...",
+                    timeout
+                );
+                // Stop job Jenkins
+                let stop_url =
+                    format!("{}/job/{}/{}/stop", jenkins_url, jenkins_job_name, build_id);
+                client
+                    .post(&stop_url)
+                    .basic_auth(jenkins_user, Some(jenkins_token))
+                    .send()?;
+                sleep(Duration::from_secs(60));
+                /*
+                 * Get to latest ID job daily_regression_test to Stop it
+                 */
+                let regression_build_id = get_last_build_id(
+                    jenkins_user,
+                    jenkins_token,
+                    jenkins_url,
+                    daily_regression_test,
+                )?;
+                println!("IDR: {}", regression_build_id);
+                let stop_regression_url = format!(
+                    "{}/job/{}/{}/stop",
+                    jenkins_url, daily_regression_test, regression_build_id
+                );
+                client
+                    .post(&stop_regression_url)
+                    .basic_auth(jenkins_user, Some(jenkins_token))
+                    .send()?;
+                sleep(Duration::from_secs(60));
+                return Ok(());
+            }
+            // Sleep 30 seconds then re-run
+            sleep(Duration::from_secs(30));
+        }
+    }
+
+    /* Do read JSON file
+     * # Arguments
+     * - `file_path`: file path to configure JSON.
+     * # Return:
+     * Return `Result` inculde configure or error.
+     * Example:
+     *  ci_jenkins path/jenkinsCfg.json
+     */
+    use serde::{Deserialize, Serialize};
+    use std::fs::File;
+    use std::io::Read;
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Config {
+        pub jenkin_user: String,
+        pub jenkin_token: String,
+        pub jenkin_url: String,
+        pub daily_rebase_check: String,
+        pub daily_main_check: String,
+        pub daily_rergression_test: String,
+        pub time_out: u16,
+    }
+    pub fn read_json_cfg(file_path: &str) -> Result<Config, Box<dyn Error>> {
+        let mut file = File::open(file_path).map_err(|e| Box::new(e) as Box<dyn Error>)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .map_err(|e| Box::new(e) as Box<dyn Error>)?;
+        let config: Config =
+            serde_json::from_str(&contents).map_err(|e| Box::new(e) as Box<dyn Error>)?;
+        Ok(config)
+    }
+}


### PR DESCRIPTION
The feature allows triggering a Jenkins job to run through reading input parameters from a JSON file.

Tested:
  To-do: ci_jenkins <path/jsonCfg.file>
  1. Remote trigger job name [1]. Job [1] will call job [3] running.
  2. Timeout inside 10 hours if [1] does not complete, will stop job [1] [3]
  3. Job [2] will run when Job [1] complete or end of timeout 10 hours.

  [1]: OBMC_Daily_Rebase_Check
  [2]: OBMC_Daily_Main_Check
  [3]: OBMC_Daily_Regression_Test